### PR TITLE
fix(nvim): patch shift-tab shortcut

### DIFF
--- a/modules/profiles/development/nvim/tabline.nix
+++ b/modules/profiles/development/nvim/tabline.nix
@@ -18,7 +18,7 @@ in {
           mappings = {
             closeCurrent = "<leader>x";
             cycleNext = "<tab>";
-            cyclePrevious = "<shift><tab>";
+            cyclePrevious = "<S-Tab>";
           };
 
           setupOpts.options = {


### PR DESCRIPTION
Closes #118

