### PR TITLE
fix(flake): disable checks for pipx and ldap

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726696,
-        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
@@ -394,11 +394,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1779461836,
-        "narHash": "sha256-iV6reLT7o1XfofI+mLuFZl7TdDXzsnniXge6aFXjjrc=",
+        "lastModified": 1780042000,
+        "narHash": "sha256-RxFOqPMAlbWiWwh7CQ0bIHIdt4D5gAttx3YVifBBWgE=",
         "owner": "notashelf",
         "repo": "nvf",
-        "rev": "21849b62be17c6657accbf4e0c9e1afe57e27ea3",
+        "rev": "07b57ebc6c9e778c536ac0ff1b01fb18dc90239a",
         "type": "github"
       },
       "original": {
@@ -575,11 +575,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -1,12 +1,16 @@
 # feature: common settings
-{inputs, ...}: {
+{
+  inputs,
+  self,
+  ...
+}: {
   flake.nixosModules.core = {
     lib,
     pkgs,
     config,
     ...
   }: {
-    imports = [inputs.sops-nix.nixosModules.sops];
+    imports = [inputs.sops-nix.nixosModules.sops self.nixosModules.patches];
 
     options.stars = {
       mainUser = lib.mkOption {

--- a/modules/patches.nix
+++ b/modules/patches.nix
@@ -1,0 +1,18 @@
+_: {
+  flake.nixosModules.patches = _: {
+    nixpkgs.overlays = [
+      (_final: prev: {
+        # openldap 2.6.13: flaky sync-replication test (test017) fails non-deterministically
+        openldap =
+          if prev.openldap.version == "2.6.13"
+          then prev.openldap.overrideAttrs {doCheck = false;}
+          else prev.openldap;
+        # pipx 1.8.0: tests assert no space before @ in package specs, but 1.8.0 adds one
+        pipx =
+          if prev.pipx.version == "1.8.0"
+          then prev.pipx.overrideAttrs {doInstallCheck = false;}
+          else prev.pipx;
+      })
+    ];
+  };
+}


### PR DESCRIPTION
They fail in nixpkgs.
