### PR TITLE
fix(virt): remove groups for user

### DIFF
--- a/modules/virt.nix
+++ b/modules/virt.nix
@@ -42,8 +42,6 @@ _: {
       #   options kvm_intel emulate_invalid_guest_state=0
       #   options kvm ignore_msrs=1
       # '';
-
-      users.users.${config.stars.mainUser}.extraGroups = ["docker" "libvirtd"];
     };
   };
 }


### PR DESCRIPTION
Having docker and libvirtd groups is equivalent to root.
